### PR TITLE
Updated create statement of riskfactor table to prevent mapping error

### DIFF
--- a/tutorials/hortonworks/hello-hdp-an-introduction-to-hadoop/hello-hdp-section-5.md
+++ b/tutorials/hortonworks/hello-hdp-an-introduction-to-hadoop/hello-hdp-section-5.md
@@ -52,7 +52,7 @@ Pig scripts are **translated into a series of MapReduce jobs** that are **run on
 Next, you will use Pig to compute the risk factor of each driver. **Before we can run the Pig code**, the _table must already exist in Hive_ to satisfy one of the _requirements for the HCatStorer() class_. The Pig code expects the following structure for a table named **riskfactor**. Execute the following DDL command:
 
 ~~~
-CREATE TABLE riskfactor (driverid string,events bigint,totmiles bigint,riskfactor float)
+CREATE TABLE riskfactor (driverid string,events bigint,totmiles double,riskfactor float)
 STORED AS ORC;
 ~~~
 


### PR DESCRIPTION
Fixes Issue # .

This pull request aims to addres:
Fix for error reported by customer: 

 https://community.hortonworks.com/questions/58614/i-need-help-with-the-riskfactor-pig-script-from-th.html

file script.pig, line 9, column 0> Output Location Validation Failed for: 'riskfactor More info to follow:
Pig 'double' type in column 2(0-based) cannot map to HCat 'BIGINT'type.  Target filed must be of HCat type {DOUBLE}
