### PR TITLE
Modify HDF tutorial website: sections and titles

### DIFF
--- a/tutorials/cda/analyze-iot-weather-station-data-via-connected-data-architecture/tutorial-0.md
+++ b/tutorials/cda/analyze-iot-weather-station-data-via-connected-data-architecture/tutorial-0.md
@@ -10,7 +10,7 @@ technology: Apache NiFi, MiNiFi, Raspberry Pi, Apache Zookeeper, Apache HBase, A
 release: hdp-2.6.4, hdf-3.0.2
 environment: Sandbox
 product: HDF
-series: HDF > Hadoop for Data Scientists & Analysts > Real World Examples
+series: HDF > Develop with Hadoop > Real World Examples
 ---
 
 # Analyze IoT Weather Station Data via Connected Data Architecture

--- a/tutorials/cda/analyze-iot-weather-station-data-via-connected-data-architecture/tutorial-0.md
+++ b/tutorials/cda/analyze-iot-weather-station-data-via-connected-data-architecture/tutorial-0.md
@@ -10,7 +10,7 @@ technology: Apache NiFi, MiNiFi, Raspberry Pi, Apache Zookeeper, Apache HBase, A
 release: hdp-2.6.4, hdf-3.0.2
 environment: Sandbox
 product: HDF
-series: HDF > Develop with Hadoop > Real World Examples
+series: HDF > Develop Data Flow & Streaming Applications > Real World Examples
 ---
 
 # Analyze IoT Weather Station Data via Connected Data Architecture

--- a/tutorials/hdf/analyze-transit-pattern-with-apache-nifi/tutorial-0.md
+++ b/tutorials/hdf/analyze-transit-pattern-with-apache-nifi/tutorial-0.md
@@ -10,7 +10,7 @@ technology: Apache NiFi
 release: hdf-3.1.0
 environment: Sandbox
 product: HDF
-series: HDF > Develop Data Flow & Streaming Applications > Hello World
+series: HDF > Develop Data Flow & Streaming Applications > Real World Examples
 ---
 
 

--- a/tutorials/hdf/analyze-transit-pattern-with-apache-nifi/tutorial-0.md
+++ b/tutorials/hdf/analyze-transit-pattern-with-apache-nifi/tutorial-0.md
@@ -10,7 +10,7 @@ technology: Apache NiFi
 release: hdf-3.1.0
 environment: Sandbox
 product: HDF
-series: HDF > Develop with Hadoop > Hello World
+series: HDF > Develop Data Flow & Streaming Applications > Hello World
 ---
 
 

--- a/tutorials/hdf/getting-started-with-hdf-sandbox/tutorial.md
+++ b/tutorials/hdf/getting-started-with-hdf-sandbox/tutorial.md
@@ -10,7 +10,7 @@ technology: Apache Ambari, Apache Storm, Apache Superset, Apache NiFi, Schema Re
 release: hdf-3.0.2
 environment: Sandbox
 product: HDF
-series: HDF > Develop with Hadoop > Hello World
+series: HDF > Develop Data Flow & Streaming Applications > Hello World
 ---
 
 # Getting Started with Hortonworks DataFlow (HDF) Sandbox

--- a/tutorials/hdf/kafka-trucking-iot-on-hdf/tutorial-0.md
+++ b/tutorials/hdf/kafka-trucking-iot-on-hdf/tutorial-0.md
@@ -10,7 +10,7 @@ technology: Apache Kafka
 release: hdf-3.1
 environment: Sandbox
 product: HDF
-series: HDF > Develop Data Flow & Streaming Applications > Real World Examples
+series: HDF > Develop Data Flow & Streaming Applications > Hello World
 ---
 
 # Kafka in Trucking IoT on Hortonworks DataFlow (HDF)

--- a/tutorials/hdf/kafka-trucking-iot-on-hdf/tutorial-0.md
+++ b/tutorials/hdf/kafka-trucking-iot-on-hdf/tutorial-0.md
@@ -10,7 +10,7 @@ technology: Apache Kafka
 release: hdf-3.1
 environment: Sandbox
 product: HDF
-series: HDF > Develop with Hadoop > Real World Examples
+series: HDF > Develop Data Flow & Streaming Applications > Real World Examples
 ---
 
 # Kafka in Trucking IoT on Hortonworks DataFlow (HDF)

--- a/tutorials/hdf/nifi-trucking-iot-on-hdf/tutorial-0.md
+++ b/tutorials/hdf/nifi-trucking-iot-on-hdf/tutorial-0.md
@@ -10,7 +10,7 @@ technology: Apache NiFi
 release: hdf-3.1
 environment: Sandbox
 product: HDF
-series: HDF > Develop Data Flow & Streaming Applications > Real World Examples
+series: HDF > Develop Data Flow & Streaming Applications > Hello World
 ---
 
 # NiFi in Trucking IoT on HDF

--- a/tutorials/hdf/nifi-trucking-iot-on-hdf/tutorial-0.md
+++ b/tutorials/hdf/nifi-trucking-iot-on-hdf/tutorial-0.md
@@ -10,7 +10,7 @@ technology: Apache NiFi
 release: hdf-3.1
 environment: Sandbox
 product: HDF
-series: HDF > Develop with Hadoop > Real World Examples
+series: HDF > Develop Data Flow & Streaming Applications > Real World Examples
 ---
 
 # NiFi in Trucking IoT on HDF

--- a/tutorials/hdf/realtime-event-processing-in-hadoop-with-nifi-kafka-and-storm/tutorial-0.md
+++ b/tutorials/hdf/realtime-event-processing-in-hadoop-with-nifi-kafka-and-storm/tutorial-0.md
@@ -10,7 +10,7 @@ technology: Apache NiFi, Apache Storm, Apache Kafka, Apache Hive, HDFS, Apache H
 release: hdf-2.1.0
 environment: Sandbox
 product: HDF
-series: HDF > Develop with Hadoop > Real World Examples
+series: HDF > Develop Data Flow & Streaming Applications > Real World Examples
 ---
 
 # Realtime Event Processing in Hadoop with NiFi, Kafka and Storm

--- a/tutorials/hdf/realtime-event-processing-in-hadoop-with-nifi-kafka-and-storm/tutorial-0.md
+++ b/tutorials/hdf/realtime-event-processing-in-hadoop-with-nifi-kafka-and-storm/tutorial-0.md
@@ -10,7 +10,7 @@ technology: Apache NiFi, Apache Storm, Apache Kafka, Apache Hive, HDFS, Apache H
 release: hdf-2.1.0
 environment: Sandbox
 product: HDF
-series: HDF > Develop Data Flow & Streaming Applications > Real World Examples
+series: HDF > Develop Data Flow & Streaming Applications > Hello World
 ---
 
 # Realtime Event Processing in Hadoop with NiFi, Kafka and Storm

--- a/tutorials/hdf/realtime-event-processing-in-nifi-sam-sr-superset/tutorial.md
+++ b/tutorials/hdf/realtime-event-processing-in-nifi-sam-sr-superset/tutorial.md
@@ -10,7 +10,7 @@ technology: Apache NiFi, Apache Storm, Apache Kafka, Streaming Analytics Manager
 release: hdf-3.0.2
 environment: Sandbox
 product: HDF
-series: HDF > Develop Data Flow & Streaming Applications > Real World Examples
+series: HDF > Develop Data Flow & Streaming Applications > Hello World
 ---
 
 # Real-Time Event Processing In NiFi, SAM, Schema Registry and Superset

--- a/tutorials/hdf/realtime-event-processing-in-nifi-sam-sr-superset/tutorial.md
+++ b/tutorials/hdf/realtime-event-processing-in-nifi-sam-sr-superset/tutorial.md
@@ -10,7 +10,7 @@ technology: Apache NiFi, Apache Storm, Apache Kafka, Streaming Analytics Manager
 release: hdf-3.0.2
 environment: Sandbox
 product: HDF
-series: HDF > Develop with Hadoop > Real World Examples
+series: HDF > Develop Data Flow & Streaming Applications > Real World Examples
 ---
 
 # Real-Time Event Processing In NiFi, SAM, Schema Registry and Superset

--- a/tutorials/hdf/sam-trucking-iot-on-hdf/tutorial-0.md
+++ b/tutorials/hdf/sam-trucking-iot-on-hdf/tutorial-0.md
@@ -10,7 +10,7 @@ technology: Streaming Analytics Manager
 release: hdf-3.1
 environment: Sandbox
 product: HDF
-series: HDF > Develop Data Flow & Streaming Applications > Real World Examples
+series: HDF > Develop Data Flow & Streaming Applications > Hello World
 ---
 
 # SAM in Trucking IoT on HDF

--- a/tutorials/hdf/sam-trucking-iot-on-hdf/tutorial-0.md
+++ b/tutorials/hdf/sam-trucking-iot-on-hdf/tutorial-0.md
@@ -10,7 +10,7 @@ technology: Streaming Analytics Manager
 release: hdf-3.1
 environment: Sandbox
 product: HDF
-series: HDF > Develop with Hadoop > Real World Examples
+series: HDF > Develop Data Flow & Streaming Applications > Real World Examples
 ---
 
 # SAM in Trucking IoT on HDF

--- a/tutorials/hdf/storm-trucking-iot-on-hdf/tutorial-0.md
+++ b/tutorials/hdf/storm-trucking-iot-on-hdf/tutorial-0.md
@@ -10,7 +10,7 @@ technology: Apache Storm, Apache Kafka
 release: hdf-3.1.1
 environment: Sandbox
 product: HDF
-series: HDF > Develop with Hadoop > Real World Examples
+series: HDF > Develop Data Flow & Streaming Applications > Real World Examples
 ---
 
 # Storm in Trucking IoT on HDF

--- a/tutorials/hdf/storm-trucking-iot-on-hdf/tutorial-0.md
+++ b/tutorials/hdf/storm-trucking-iot-on-hdf/tutorial-0.md
@@ -10,7 +10,7 @@ technology: Apache Storm, Apache Kafka
 release: hdf-3.1.1
 environment: Sandbox
 product: HDF
-series: HDF > Develop Data Flow & Streaming Applications > Real World Examples
+series: HDF > Develop Data Flow & Streaming Applications > Hello World
 ---
 
 # Storm in Trucking IoT on HDF

--- a/tutorials/hdf/superset-trucking-iot-on-hdf/tutorial-0.md
+++ b/tutorials/hdf/superset-trucking-iot-on-hdf/tutorial-0.md
@@ -10,7 +10,7 @@ technology: Apache Superset
 release: hdf-3.0.2
 environment: Sandbox
 product: HDF
-series: HDF > Develop Data Flow & Streaming Applications > Real World Examples
+series: HDF > Develop Data Flow & Streaming Applications > Hello World
 ---
 
 # Superset in Trucking IoT on HDF

--- a/tutorials/hdf/superset-trucking-iot-on-hdf/tutorial-0.md
+++ b/tutorials/hdf/superset-trucking-iot-on-hdf/tutorial-0.md
@@ -10,7 +10,7 @@ technology: Apache Superset
 release: hdf-3.0.2
 environment: Sandbox
 product: HDF
-series: HDF > Hadoop For Data Scientists & Analysts > Real World Examples
+series: HDF > Develop with Hadoop > Real World Examples
 ---
 
 # Superset in Trucking IoT on HDF

--- a/tutorials/hdf/superset-trucking-iot-on-hdf/tutorial-0.md
+++ b/tutorials/hdf/superset-trucking-iot-on-hdf/tutorial-0.md
@@ -10,7 +10,7 @@ technology: Apache Superset
 release: hdf-3.0.2
 environment: Sandbox
 product: HDF
-series: HDF > Develop with Hadoop > Real World Examples
+series: HDF > Develop Data Flow & Streaming Applications > Real World Examples
 ---
 
 # Superset in Trucking IoT on HDF


### PR DESCRIPTION
**Fixes issue**: <Add link to GitHub issue here>

**This pull request addresses**:
Modify HDF tutorial website: sections and titles:

- delete HADOOP FOR DATA SCIENTISTS & ANALYSTS
- rename DEVELOP WITH HADOOP -> Develop Data Flow & Streaming Applications
- move tutorials to specific sections