### PR TITLE
Updated link to Zeppelin Notebook

### DIFF
--- a/tutorials/hdp/hadoop-tutorial-getting-started-with-hdp/tutorial-5.md
+++ b/tutorials/hdp/hadoop-tutorial-getting-started-with-hdp/tutorial-5.md
@@ -60,7 +60,7 @@ Let's get started!
 2\. Open Zeppelin interface using browser URL:
 
 ~~~
-http://sandbox.hortonworks.com:9995
+http://sandbox-hdp.hortonworks.com:9995/
 ~~~
 
 You should see a Zeppelin Welcome Page:

--- a/tutorials/hdp/hadoop-tutorial-getting-started-with-hdp/tutorial-6.md
+++ b/tutorials/hdp/hadoop-tutorial-getting-started-with-hdp/tutorial-6.md
@@ -45,7 +45,7 @@ riskfactor data that we've collected earlier and visualize the result through gr
 Open Zeppelin interface using browser URL:
 
 ~~~
-http://sandbox.hortonworks.com:9995
+http://sandbox-hdp.hortonworks.com:9995/
 ~~~
 
 ![Zeppelin Dashboard](assets/zeppelin_welcome_page_hello_hdp_lab4.png)


### PR DESCRIPTION
**Fixes issue**: <Add link to GitHub issue here>

**This pull request addresses**:
Updated link access to Zeppelin Notebook from "http://sandbox.hortonworks.com:9995"
to "http://sandbox-hdp.hortonworks.com:9995/"