### PR TITLE
Upating tutorial track

### DIFF
--- a/tutorials/hdp/deploying-machine-learning-models-with-spark-structured-streaming/tutorial.md
+++ b/tutorials/hdp/deploying-machine-learning-models-with-spark-structured-streaming/tutorial.md
@@ -10,7 +10,7 @@ technology: Apache Spark
 release: hdp-2.6.0
 environment: Sandbox
 product: HDP
-series: HDP > Develop with Hadoop > Apache Spark
+series: HDP > Develop with Hadoop > Real World Examples, HDP > Hadoop for Data Scientists & Analysts > Real World Examples
 ---
 
 

--- a/tutorials/hdp/deploying-machine-learning-models-with-spark-structured-streaming/tutorial.md
+++ b/tutorials/hdp/deploying-machine-learning-models-with-spark-structured-streaming/tutorial.md
@@ -10,7 +10,7 @@ technology: Apache Spark
 release: hdp-2.6.0
 environment: Sandbox
 product: HDP
-series: HDP > Develop with Hadoop > Real World Examples, HDP > Hadoop for Data Scientists & Analysts > Real World Examples
+series: HDP > Hadoop for Data Scientists & Analysts > Real World Examples
 ---
 
 


### PR DESCRIPTION
**Fixes issue**: Sets tutorial under Real World examples track as opposed to Spark. This was done because this tutorial is not solely Spark there are HDF components to it.

**This pull request addresses**:
