### PR TITLE
Update nifi-auto-deploy.sh (#801)

### DIFF
--- a/tutorials/cda/building-a-server-log-analysis-application/application/development/shell/nifi-auto-deploy.sh
+++ b/tutorials/cda/building-a-server-log-analysis-application/application/development/shell/nifi-auto-deploy.sh
@@ -27,7 +27,7 @@ auto_deploy_nifi()
 
   # Download NiFi Flow Template
   echo "$DATE INFO: Downloading the NIFI_TEMPLATE to location $NIFI_TEMPLATE_PATH"
-  wget https://github.com/james94/data-tutorials/raw/master/tutorials/cda/building-a-server-log-analysis-application/application/development/nifi-template/$NIFI_TEMPLATE.xml \
+  wget https://github.com/hortonworks/data-tutorials/blob/master/tutorials/cda/building-a-server-log-analysis-application/application/development/nifi-template/$NIFI_TEMPLATE.xml \
   -O $NIFI_TEMPLATE_PATH
 
   # Searches for OLD GeoLite2-City.mmdb file path in NiFi template file, then replaces OLD path with NEW path


### PR DESCRIPTION
Previous path doesn't exist anymore. Looks good. Hortonworks path for nifi template is more permanent than the one from the forked repo.

**Fixes issue**: <Add link to GitHub issue here>

**This pull request addresses**:
